### PR TITLE
Add databaseIsUnlocked(), add associateAndWait(), improve use of Optionals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ pom.xml.versionsBackup
 .idea/**/libraries/
 *.iml
 
+/.idea/copilot/
+/.idea/inspectionProfiles/

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![License](https://img.shields.io/github/license/purejava/keepassxc-proxy-access.svg)](https://github.com/purejava/keepassxc-proxy-access/blob/master/LICENSE)
 [![Donate](https://img.shields.io/badge/Donate-PayPal-green.svg)](https://www.paypal.com/donate?hosted_button_id=XVX9ZM7WE4ANL)
 
-A Java library to access KeePassXC via its build-in proxy. Requires KeePassXC 2.6.0 or newer.
+A Java library to access KeePassXC via its built-in proxy. Requires KeePassXC 2.6.0 or newer.
 
 # Dependency
 Add `keepassxc-proxy-access` as a dependency to your project.

--- a/src/main/java/org/keepassxc/Connection.java
+++ b/src/main/java/org/keepassxc/Connection.java
@@ -27,7 +27,7 @@ public abstract class Connection implements AutoCloseable {
     private final PropertyChangeSupport support;
 
     private TweetNaclFast.Box box;
-    private Optional<Credentials> credentials;
+    private Credentials credentials;
     private final String clientID;
     private static final int nonceLength = 24;
     private byte[] nonce;
@@ -87,7 +87,6 @@ public abstract class Connection implements AutoCloseable {
         new Random().nextBytes(array);
         clientID = b64encode(array);
         nonce = TweetNaclFast.randombytes(nonceLength);
-        credentials = Optional.empty();
         support = new PropertyChangeSupport(this);
         scheduler = Executors.newSingleThreadScheduledExecutor();
     }
@@ -116,18 +115,18 @@ public abstract class Connection implements AutoCloseable {
                     if (!isSignal(response)) LOG.trace("Response added to queue: {}", response);
                     queue.offer(response);
                     errorCount = 0;
-                } else {
-                    errorCount++;
-                    if (errorCount > MAX_ERROR_COUNT) {
-                        LOG.info("Too much errors - stopping MessagePublisher");
-                        doStop();
-                        try {
-                            terminateConnection();
-                        } catch (IOException e) {
-                            LOG.error(e.toString(), e.getCause());
-                        }
-                        reconnect();
+                    continue;
+                }
+                errorCount++;
+                if (errorCount > MAX_ERROR_COUNT) {
+                    LOG.info("Too much errors - stopping MessagePublisher");
+                    doStop();
+                    try {
+                        terminateConnection();
+                    } catch (IOException e) {
+                        LOG.error(e.toString(), e.getCause());
                     }
+                    reconnect();
                 }
             }
             LOG.debug("MessagePublisher stopped");
@@ -270,8 +269,13 @@ public abstract class Connection implements AutoCloseable {
             throw new IllegalStateException(NOT_CONNECTED);
         }
 
-        var publicKey = credentials.orElseThrow(() -> new IllegalStateException(KEYEXCHANGE_MISSING)).getServerPublicKey();
-        var keyPair = credentials.orElseThrow(() -> new IllegalStateException(KEYEXCHANGE_MISSING)).getOwnKeypair();
+        var publicKey = Optional.ofNullable(credentials).orElseThrow(
+            () -> new IllegalStateException(KEYEXCHANGE_MISSING)
+        ).getServerPublicKey();
+
+        var keyPair = Optional.ofNullable(credentials).orElseThrow(
+            () -> new IllegalStateException(KEYEXCHANGE_MISSING)
+        ).getOwnKeypair();
 
         if (msg.containsKey("triggerUnlock") && msg.get("triggerUnlock").equals("true")) {
             msg.remove("triggerUnlock");
@@ -386,11 +390,11 @@ public abstract class Connection implements AutoCloseable {
         var publicKey = b64decode(response.getString("publicKey").getBytes());
         box = new TweetNaclFast.Box(publicKey, keyPair.getSecretKey());
 
-        if (credentials.isEmpty()) {
-            setCredentials(Optional.of(new Credentials()));
+        if (Optional.ofNullable(credentials).isEmpty()) {
+            setCredentials(null);
         }
-        credentials.orElseThrow(() -> new IllegalStateException(MISSING_CLASS)).setOwnKeypair(keyPair);
-        credentials.orElseThrow(() -> new IllegalStateException(MISSING_CLASS)).setServerPublicKey(publicKey);
+        Optional.ofNullable(credentials).orElseThrow(() -> new IllegalStateException(MISSING_CLASS)).setOwnKeypair(keyPair);
+        Optional.ofNullable(credentials).orElseThrow(() -> new IllegalStateException(MISSING_CLASS)).setServerPublicKey(publicKey);
         support.firePropertyChange("credentialsCreated", null, credentials);
 
     }
@@ -404,7 +408,8 @@ public abstract class Connection implements AutoCloseable {
      */
     public void associate() throws IOException, KeepassProxyAccessException {
         var idKeyPair = TweetNaclFast.Box.keyPair();
-        var keyPair = credentials.orElseThrow(() -> new IllegalStateException(KEYEXCHANGE_MISSING)).getOwnKeypair();
+        var keyPair = Optional.ofNullable(credentials).orElseThrow(
+            () -> new IllegalStateException(KEYEXCHANGE_MISSING)).getOwnKeypair();
 
         // Send associate request
         var nonce = sendEncryptedMessage(Map.of(
@@ -427,8 +432,12 @@ public abstract class Connection implements AutoCloseable {
                 LOG.error(e.toString(), e.getCause());
             }
             assert response != null;
-            credentials.orElseThrow(() -> new IllegalStateException(MISSING_CLASS)).setAssociateId(response.getString("id"));
-            credentials.orElseThrow(() -> new IllegalStateException(MISSING_CLASS)).setIdKeyPublicKey(idKeyPair.getPublicKey());
+            Optional.ofNullable(credentials).orElseThrow(
+                () -> new IllegalStateException(MISSING_CLASS)).setAssociateId(response.getString("id"));
+
+            Optional.ofNullable(credentials).orElseThrow(
+                () -> new IllegalStateException(MISSING_CLASS)).setIdKeyPublicKey(idKeyPair.getPublicKey());
+
             support.firePropertyChange("associated", null, credentials);
         };
         scheduler.schedule(lookupResponse, RESPONSE_DELAY_MS, TimeUnit.MILLISECONDS);
@@ -438,16 +447,20 @@ public abstract class Connection implements AutoCloseable {
     /**
      * Request for receiving the database hash (SHA256) of the current active KeePassXC database.
      *
-     * @return The database hash of the current active KeePassXC database.
+     * @return The database hash of the current active KeePassXC database. Empty if the database is locked.
      * @throws IOException                 Retrieving the hash failed due to technical reasons.
      * @throws KeepassProxyAccessException It was impossible to get the hash.
      */
-    public String getDatabasehash() throws IOException, KeepassProxyAccessException {
+    public Optional<String> getDatabasehash() throws IOException, KeepassProxyAccessException {
         // Send get-databasehash request
         var nonce = sendEncryptedMessage(Map.of("action", Message.GET_DATABASE_HASH.action));
         var response = getEncryptedResponseAndDecrypt(Message.GET_DATABASE_HASH.action, nonce);
 
-        return response.getString("hash");
+        if (response.has("hash") && !response.getString("hash").isBlank()) {
+            return Optional.of(response.getString("hash"));
+        }
+
+        return Optional.empty();
     }
 
     /**
@@ -459,7 +472,7 @@ public abstract class Connection implements AutoCloseable {
      * @throws IOException                 Retrieving the hash failed due to technical reasons.
      * @throws KeepassProxyAccessException It was impossible to get the hash.
      */
-    public String getDatabasehash(boolean triggerUnlock) throws IOException, KeepassProxyAccessException {
+    public Optional<String> getDatabasehash(boolean triggerUnlock) throws IOException, KeepassProxyAccessException {
         // Send get-databasehash request with triggerUnlock, if needed
         var map = new HashMap<String, Object>(); // Map.of can't be used here, because we need a mutable object
         map.put("action", Message.GET_DATABASE_HASH.action);
@@ -467,7 +480,7 @@ public abstract class Connection implements AutoCloseable {
         var nonce = sendEncryptedMessage(map);
         var response = getEncryptedResponseAndDecrypt(Message.GET_DATABASE_HASH.action, nonce);
 
-        return response.getString("hash");
+        return Optional.ofNullable(response.getString("hash"));
     }
 
     /**
@@ -832,15 +845,15 @@ public abstract class Connection implements AutoCloseable {
     }
 
     // Getters and Setters
-    public String getIdKeyPairPublicKey() {
-        return credentials.map(value -> b64encode(value.getIdKeyPublicKey())).orElse("");
+    public Optional<String> getIdKeyPairPublicKey() {
+        return Optional.ofNullable(credentials).map(value -> b64encode(value.getIdKeyPublicKey()));
     }
 
-    public String getAssociateId() {
-        return credentials.map(Credentials::getAssociateId).orElse("");
+    public Optional<String> getAssociateId() {
+        return Optional.ofNullable(this.credentials).flatMap(Credentials::getAssociateId);
     }
 
-    public void setCredentials(Optional<Credentials> credentials) {
+    public void setCredentials(Credentials credentials) {
         this.credentials = credentials;
     }
 

--- a/src/main/java/org/purejava/Credentials.java
+++ b/src/main/java/org/purejava/Credentials.java
@@ -15,16 +15,11 @@ public class Credentials implements Serializable {
 
     private byte[] serverPublicKey;
 
-    private transient Optional<String> associateId;
+    private transient String associateId;
     private String aID;
 
-    private transient Optional<byte[]> idKeyPublicKey;
+    private transient byte[] idKeyPublicKey;
     private byte[] idKeyPub;
-
-    public Credentials() {
-        this.associateId = Optional.empty();
-        this.idKeyPublicKey = Optional.empty();
-    }
 
     @Serial
     private void readObject(ObjectInputStream ois) throws ClassNotFoundException, IOException {
@@ -38,7 +33,7 @@ public class Credentials implements Serializable {
     @Serial
     private void writeObject(ObjectOutputStream oos) throws IOException {
         secretKey = ownKeypair.getSecretKey();
-        aID = getAssociateId();
+        aID = getAssociateId().orElse(null);
         idKeyPub = getIdKeyPublicKey();
         oos.defaultWriteObject();
     }
@@ -60,27 +55,32 @@ public class Credentials implements Serializable {
         this.serverPublicKey = serverPublicKey;
     }
 
-    public String getAssociateId() {
-        return associateId.isEmpty() ? "" : associateId.get();
+    public Optional<String> getAssociateId() {
+        if (associateId == null || associateId.isEmpty())
+            return Optional.empty();
+
+        return Optional.of(associateId);
     }
 
     public void setAssociateId(String associateId) {
         if (associateId.isEmpty()) {
-            this.associateId = Optional.empty();
-        } else {
-            this.associateId = Optional.of(associateId);
+            this.associateId = null;
+            return;
         }
+
+        this.associateId = associateId;
     }
 
     public byte[] getIdKeyPublicKey() {
-        return idKeyPublicKey.isEmpty() ? new byte[]{} : idKeyPublicKey.get();
+        return Optional.ofNullable(idKeyPublicKey).isEmpty() ? new byte[]{} : idKeyPublicKey;
     }
 
     public void setIdKeyPublicKey(byte[] idKeyPublicKey) {
         if (idKeyPublicKey.length == 0) {
-            this.idKeyPublicKey = Optional.empty();
-        } else {
-            this.idKeyPublicKey = Optional.of(idKeyPublicKey);
+            this.idKeyPublicKey = null;
+            return;
         }
+
+        this.idKeyPublicKey = idKeyPublicKey;
     }
 }

--- a/src/main/java/org/purejava/KeepassProxyAccess.java
+++ b/src/main/java/org/purejava/KeepassProxyAccess.java
@@ -285,6 +285,12 @@ public class KeepassProxyAccess implements PropertyChangeListener {
         }
     }
 
+    /**
+     * Request for receiving the database hash (SHA256) of the current active KeePassXC database.
+     * @return The database hash of the current active KeePassXC database in case the hash could be retrieved,
+     *         an empty String otherwise.
+     * @see #getDatabasehash(boolean)
+     */
     public Optional<String> getDatabasehash() {
         try {
             return connection.getDatabasehash();

--- a/src/test/java/org/purejava/LockedDatabaseTest.java
+++ b/src/test/java/org/purejava/LockedDatabaseTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -17,7 +18,8 @@ public class LockedDatabaseTest {
     @DisplayName("Testing connection over socket to KeePassXC")
     public void shouldHaveNoErrors() {
         assertTrue(kpa.connect());
-        assertTrue(kpa.getDatabasehash().isEmpty());
+        assertFalse(kpa.databaseIsUnlocked());
+        assertTrue(kpa.getDatabasehash().isEmpty() || kpa.getDatabasehash().get().isEmpty());
         assertTrue(kpa.shutdown());
     }
 }


### PR DESCRIPTION
First of all, many thanks for creating such an awesome and outstandingly helpful library!

I noticed a few things that IMHO could be improved – which I tried to do; I hope that's okay :)

## Is the database unlocked?

When I first integrated KeePassXC-Proxy-Access into my own project a couple of days ago, I didn't immediately understand how I could check whether the user's password database is unlocked. Therefore, I implemented a public `databaseIsUnlocked` method in `KeepassProxyAccess` that does the job for the library caller (by simply checking the presence of the database hash).

## Wait for the user to enter an associate ID

It took me a while to understand that `KeePassProxyAccess#associate` does *NOT* wait for the user to accept the association and enter an application name in KeePassXC, as I assumed that `associate` surely must be blocking.

Therefore, I implemented a new method named `associateAndWait` that is, in fact, blocking. It basically retries `testAssociate` every 100 milliseconds and times out after 60 seconds. This gives the user one minute to accept the association, enter an application name and save the password database.

It was important to me to make the timeout configurable, because saving the database could take KeePassXC differently long on different devices. If the library caller already knows that the device is a bit slow, they can adjust the timeout as needed. Also, I have adjusted the encryption parameters of my very own personal database such that the decryption or saving process takes half a minute with my 11th-gen Intel i7. 😉

## Nesting

I tried to partly "unnest" the code in order to make it slightly more readable. For example, in this case, the `else` case (including the indentation) is redundant if we just add a `continue` statement to the `if` case:

**Old**:

```
while (keepRunning()) {
    var response = getCleartextResponse();
    if (!response.isEmpty()) {
        if (!isSignal(response)) LOG.trace("Response added to queue: {}", response);
        queue.offer(response);
        errorCount = 0;
    } else {
        errorCount++;
        if (errorCount > MAX_ERROR_COUNT) {
            LOG.info("Too much errors - stopping MessagePublisher");
            doStop();
            try {
                terminateConnection();
            } catch (IOException e) {
                LOG.error(e.toString(), e.getCause());
            }
            reconnect();
        }
    }
}
```

**New** (does the exact same):

```
while (keepRunning()) {
    var response = getCleartextResponse();
    if (!response.isEmpty()) {
        if (!isSignal(response)) LOG.trace("Response added to queue: {}", response);
        queue.offer(response);
        errorCount = 0;
        continue;
    }
    errorCount++;
    if (errorCount > MAX_ERROR_COUNT) {
        LOG.info("Too much errors - stopping MessagePublisher");
        doStop();
        try {
            terminateConnection();
        } catch (IOException e) {
            LOG.error(e.toString(), e.getCause());
        }
        reconnect();
    }
}
```

## Duplicate code

I outsourced a duplicated portion of `KeepassProxyAccess#passkeysRegister` and `KeepassProxyAccess#passkeysGet` to a new private method named `parsePasskeysResponse`, and I tried my best to make it a bit easier to understand intuitively.

## `getDatabasehash(boolean...)`

It took me quite a while to understand why the `KeepassProxyAccess#getDatabasehash` method takes an arbitrary number of boolean arguments, until I finally understood that the number of arguments isn't actually arbitrary but must be either zero or one. In order to reduce the confusion for other library callers, I split the method into two methods, one of which takes no arguments and the other takes one boolean.

## Optionals

As explained [here](https://rules.sonarsource.com/java/RSPEC-3553), it is not desirable to use Optionals as input parameters for methods, because that increases the number of cases from two (null, non-null) to three (null, empty, present). The same goes for object fields, because the object's methods can never be certain that an Optional field is not itself null (which would cause all method calls like `Optional#get` to cause a NullPointerException).

Instead, Optionals should be used as return types, in order to explicitly indicate to the caller of a library method that there is nothing to return. For example, returning an empty Optional is IMHO better suited to indicate that there is no database hash available than returning an empty string.

Therefore, I took the liberty to refactor the code such that:

- `Connection#credentials`, `Credentials#idKeyPublicKey` and `Credentials#associateId` aren't Optionals anymore and are instead initially null
- `getDatabasehash()`, `getIdKeyPairPublicKey()` and `getAssociateId` return `Optional<String>` instead of `String`